### PR TITLE
Epsilon func values now support variable shapes

### DIFF
--- a/scsr/maths.py
+++ b/scsr/maths.py
@@ -581,6 +581,13 @@ def ensure_numpy_array(obj: ndarray) -> ndarray:
     return obj
 
 
+def get_epsilon_function_shapes(results):
+    shapes_by_fn = dict.fromkeys(EPSILON_FUNCTIONS, ())
+    lc = results.parameters["lc"]
+    shapes_by_fn["Chim"] = shapes_by_fn["Chip"] = (lc, lc)
+    return shapes_by_fn
+
+
 def get_epsilon_at_index(results, index: int) -> Tuple[ndarray, ...]:
     """Calculate stuff.
 

--- a/scsr/results.py
+++ b/scsr/results.py
@@ -423,7 +423,9 @@ class EpsilonResultsProcessor(ProcessorBase, EpsilonResults):
             )
 
     def size_estimate(self):
-        return np.sum([arr.size for arr in self.epsilon_values.values()], dtype=np.int64) * maths.xp.dtype(self.dtype).itemsize
+        total_arr_size = [arr.size for arr in self.epsilon_values.values()]
+        dtype_size = maths.xp.dtype(self.dtype).itemsize
+        return np.sum(total_arr_size, dtype=np.int64) * dtype_size
 
     def reserve_memory(self):
         """reserve memory for the arrays.


### PR DESCRIPTION
This command no longer errors.
```bash
$ ./scsr-calc G H A1 A2 -p steps=75 lc=50 tau=50 L=100 max_tile_size=50,50 -v w=0.001:1.2:3 Kx=0.00001:0.3:3 P=0:1:3 -gwfo chi_test.pkl  -E --force
```

Updated the plot code too, so you can easily extract these functions:

```python
from scsr.results import load_results
results = load_results(["chi_test.pkl"])
plot_iter = results.iter_plots(axes=("w", "P"))

print("\nAll variable parameters:")
for k, v in results.variable_params.items():
    print(f"{k:<3}: {v}")

print("\nGenerating all w by P plots:")
for params, plots in plot_iter:
    changed_params = {ax: params[ax] for ax in plot_iter.extra_axes}
    print(f"Plot parameters: {changed_params}")
    for fn, plot in plots.items():
        print(f" Function {fn:>5} has plot shape: {plot.shape}")
```
Which gives the output:
```
Loading chi_test.pkl

All variable parameters:
w  : [0.001, 0.6005, 1.2]
Kx : [1e-05, 0.150005, 0.3]
P  : [0.0, 0.5, 1.0]

Generating all w by P plots:
Plot parameters: {'Kx': 1e-05}
 Function  epsp has plot shape: (3, 3)
 Function  epsm has plot shape: (3, 3)
 Function Hinvp has plot shape: (3, 3)
 Function Hinvm has plot shape: (3, 3)
 Function  Chip has plot shape: (3, 3, 50, 50)
 Function  Chim has plot shape: (3, 3, 50, 50)
Plot parameters: {'Kx': 0.150005}
 Function  epsp has plot shape: (3, 3)
 Function  epsm has plot shape: (3, 3)
 Function Hinvp has plot shape: (3, 3)
 Function Hinvm has plot shape: (3, 3)
 Function  Chip has plot shape: (3, 3, 50, 50)
 Function  Chim has plot shape: (3, 3, 50, 50)
Plot parameters: {'Kx': 0.3}
 Function  epsp has plot shape: (3, 3)
 Function  epsm has plot shape: (3, 3)
 Function Hinvp has plot shape: (3, 3)
 Function Hinvm has plot shape: (3, 3)
 Function  Chip has plot shape: (3, 3, 50, 50)
 Function  Chim has plot shape: (3, 3, 50, 50)
```
@Spraill